### PR TITLE
fix: missing modules copies in make_dataconfig_ue5.py

### DIFF
--- a/Misc/Scripts/make_dataconfig_ue5.py
+++ b/Misc/Scripts/make_dataconfig_ue5.py
@@ -28,7 +28,9 @@ plugin_src.mkdir(parents=True, exist_ok=True)
 _copytree(root_src / "DataConfigCore", plugin_src / "DataConfigCore")
 _copytree(root_src / "DataConfigExtra", plugin_src / "DataConfigExtra")
 _copytree(root_src / "DataConfigTests", plugin_src / "DataConfigTests")
+_copytree(root_src / "DataConfigTests5", plugin_src / "DataConfigTests5")
 _copytree(root_src / "DataConfigEditorExtra", plugin_src / "DataConfigEditorExtra")
+_copytree(root_src / "DataConfigEditorExtra5", plugin_src / "DataConfigExtra5")
 
 # copy others
 _copytree(root / "DataConfig/Content", plugin / "Content")


### PR DESCRIPTION
The UE5 .uproject files expects the `DataConfigTests5` and `DataConfigEditorExtra5` modules but they are not included in the `make_dataconfig_ue5.py` script.